### PR TITLE
Added support for elasticsearch 2.x.x

### DIFF
--- a/pom.xml.elasticsearch-2.0.0
+++ b/pom.xml.elasticsearch-2.0.0
@@ -1,0 +1,124 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>amazon-kinesis-connectors</artifactId>
+    <packaging>jar</packaging>
+    <name>Amazon Kinesis Connector Library</name>
+    <version>1.2.0</version>
+    <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
+    <url>https://aws.amazon.com/kinesis</url>
+
+    <scm>
+        <url>https://github.com/awslabs/amazon-kinesis-connectors.git</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>Amazon Software License</name>
+            <url>https://aws.amazon.com/asl</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <amazon-kinesis-client.version>1.4.0</amazon-kinesis-client.version>
+        <aws-java-sdk.version>1.9.37</aws-java-sdk.version>
+        <elasticsearch.version>2.0.0</elasticsearch.version>
+        <fasterxml-jackson.version>2.6.4</fasterxml-jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>amazon-kinesis-client</artifactId>
+            <version>${amazon-kinesis-client.version}</version>
+        </dependency>
+        <!-- Note that some of dependencies below are shared with the Amazon Kinesis Client library. -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws-java-sdk.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws-java-sdk.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml-jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <developers>
+        <developer>
+            <id>amazonwebservices</id>
+            <organization>Amazon Web Services</organization>
+            <organizationUrl>https://aws.amazon.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.2</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/Elasticsearch2Emitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/Elasticsearch2Emitter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.net.InetSocketAddress;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,7 +32,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.transport.NoNodeAvailableException;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
@@ -104,7 +104,7 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
 
     public ElasticsearchEmitter(KinesisConnectorConfiguration configuration) {
         Settings settings =
-                ImmutableSettings.settingsBuilder()
+                Settings.settingsBuilder()
                         .put(ELASTICSEARCH_CLUSTER_NAME_KEY, configuration.ELASTICSEARCH_CLUSTER_NAME)
                         .put(ELASTICSEARCH_CLIENT_TRANSPORT_SNIFF_KEY, configuration.ELASTICSEARCH_TRANSPORT_SNIFF)
                         .put(ELASTICSEARCH_CLIENT_TRANSPORT_IGNORE_CLUSTER_NAME_KEY,
@@ -115,9 +115,9 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
                         .build();
         elasticsearchEndpoint = configuration.ELASTICSEARCH_ENDPOINT;
         elasticsearchPort = configuration.ELASTICSEARCH_PORT;
-        LOG.info("ElasticsearchEmitter using elasticsearch endpoint " + elasticsearchEndpoint + ":" + elasticsearchPort);
-        elasticsearchClient = new TransportClient(settings);
-        elasticsearchClient.addTransportAddress(new InetSocketTransportAddress(elasticsearchEndpoint, elasticsearchPort));
+        LOG.info("Elasticsearch2Emitter using elasticsearch endpoint " + elasticsearchEndpoint + ":" + elasticsearchPort);
+        elasticsearchClient = TransportClient.builder().settings(settings).build();
+        elasticsearchClient.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(elasticsearchEndpoint, elasticsearchPort)));
     }
 
     /**


### PR DESCRIPTION
Added new pom.xml.elasticsearch-2.0.0 example for building with
elasticsearch 2.0.0 (tested on 2.0.0 and 2.0.1 so far). And added a new
Elasticsearch2Emitter.java that contains all the needed changes to make
this library work with elasticsearch 2.x.x.

//TODO - The changes in Elasticsearch2Emitter.java need to be merged
into ElasticsearchEmitter.java and the imort of "import
org.elasticsearch.common.settings.ImmutableSettings;" needs to be driven
by the version of elasticsearch used, the "ElasticsearchEmitter"
function also needs to be dependent on the version.
